### PR TITLE
replication with getAttachmentMetadata

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -574,28 +574,31 @@ function HttpPouch(opts, callback) {
       url: url,
       processData: false
     }, function(error, json, response) {
-      var meta = {};
-      var headers = response.headers || {};
+      var metadata = {};
+      if (!error) {
+        var headers = response.headers || {};
 
-      var etag = headers.etag;
-      if (etag) {
-        if (etag.substr(0, 1) == '"' && etag.substr(-1, 1) == '"') {
-          etag = etag.substr(1, etag.length - 2);
+        var etag = headers.etag;
+        if (etag) {
+          if (etag.substr(0, 1) == '"' && etag.substr(-1, 1) == '"') {
+            etag = etag.substr(1, etag.length - 2);
+          }
+
+          metadata.digest = 'md5-' + etag;
         }
-        meta.etag = 'md5-' + etag;
+
+        var contentLength = headers['content-length'];
+        if (!isNaN(contentLength)) {
+          metadata.length = contentLength;
+        }
+
+        var contentType = headers['content-type'];
+        if (contentType) {
+          metadata.content_type = contentType;
+        }
       }
 
-      var length = headers['content-length'];
-      if (!isNaN(length)) {
-        meta.length = length;
-      }
-
-      var contentType = headers['content-type'];
-      if (contentType) {
-        meta.content_type = contentType;
-      }
-
-      callback(error, meta, response);
+      callback(error, metadata, response);
     });
   });
 

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -573,7 +573,7 @@ function HttpPouch(opts, callback) {
       method: 'HEAD',
       url: url,
       processData: false
-    }, function(_, response) {
+    }, function(error, json, response) {
       var meta = {};
       var headers = response.headers || {};
 

--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -558,6 +558,47 @@ function HttpPouch(opts, callback) {
     return attachmentId.split("/").map(encodeURIComponent).join("/");
   }
 
+  // get attachment metadata
+  api.getAttachmentMetadata =
+    adapterFun('getAttachmentMetadata', function (docId, attachmentId, opts,
+                                                callback) {
+    if (typeof opts === 'function') {
+      callback = opts;
+      opts = {};
+    }
+    var params = opts.rev ? ('?rev=' + opts.rev) : '';
+    var url = genDBUrl(host, encodeDocId(docId)) + '/' +
+      encodeAttachmentId(attachmentId) + params;
+    ajax(opts, {
+      method: 'HEAD',
+      url: url,
+      processData: false
+    }, function(_, response) {
+      var meta = {};
+      var headers = response.headers || {};
+
+      var etag = headers.etag;
+      if (etag) {
+        if (etag.substr(0, 1) == '"' && etag.substr(-1, 1) == '"') {
+          etag = etag.substr(1, etag.length - 2);
+        }
+        meta.etag = 'md5-' + etag;
+      }
+
+      var length = headers['content-length'];
+      if (!isNaN(length)) {
+        meta.length = length;
+      }
+
+      var contentType = headers['content-type'];
+      if (contentType) {
+        meta.content_type = contentType;
+      }
+
+      callback(error, meta, response);
+    });
+  });
+
   // Get the attachment
   api.getAttachment =
     adapterFun('getAttachment', function (docId, attachmentId, opts,

--- a/packages/node_modules/pouchdb-ajax/src/request-browser.js
+++ b/packages/node_modules/pouchdb-ajax/src/request-browser.js
@@ -72,8 +72,14 @@ function fetchRequest(options, callback) {
   }
 
   wrappedPromise.promise.then(function (fetchResponse) {
+    var headers = {};
+    fetchResponse.headers.forEach(function(value, key) {
+      headers[key] = value;
+    });
+
     response = {
-      statusCode: fetchResponse.status
+      statusCode: fetchResponse.status,
+      headers: headers
     };
 
     if (options.timeout > 0) {
@@ -101,6 +107,28 @@ function fetchRequest(options, callback) {
   });
 
   return {abort: wrappedPromise.reject};
+}
+
+
+// https://gist.github.com/monsur/706839
+function parseResponseHeaders(headerStr) {
+  var headers = {};
+  if (!headerStr) {
+    return headers;
+  }
+  var headerPairs = headerStr.split('\u000d\u000a');
+  for (var i = 0; i < headerPairs.length; i++) {
+    var headerPair = headerPairs[i];
+    // Can't use split() here because it does the wrong thing
+    // if the header value has the string ": " in it.
+    var index = headerPair.indexOf('\u003a\u0020');
+    if (index > 0) {
+      var key = headerPair.substring(0, index);
+      var val = headerPair.substring(index + 2);
+      headers[key] = val;
+    }
+  }
+  return headers;
 }
 
 function xhRequest(options, callback) {
@@ -195,7 +223,8 @@ function xhRequest(options, callback) {
     }
 
     var response = {
-      statusCode: xhr.status
+      statusCode: xhr.status,
+      headers: parseResponseHeaders(xhr.getAllResponseHeaders())
     };
 
     if (xhr.status >= 200 && xhr.status < 300) {

--- a/packages/node_modules/pouchdb-replication/src/getDocs.js
+++ b/packages/node_modules/pouchdb-replication/src/getDocs.js
@@ -10,37 +10,25 @@ function fileHasChanged(localDoc, remoteDoc, filename) {
          localDoc._attachments[filename].digest !== remoteDoc._attachments[filename].digest;
 }
 
-function getDocAttachments(db, doc) {
-  var filenames = Object.keys(doc._attachments);
-  return Promise.all(filenames.map(function (filename) {
-    return db.getAttachment(doc._id, filename, {rev: doc._rev});
-  }));
-}
-
 function getDocAttachmentsFromTargetOrSource(target, src, doc) {
-  var doCheckForLocalAttachments = isRemote(src) && !isRemote(target);
   var filenames = Object.keys(doc._attachments);
 
-  if (!doCheckForLocalAttachments) {
-    return getDocAttachments(src, doc);
-  }
+  return Promise.all(filenames.map(function(filename) {
+    return target.getAttachmentMeta(doc._id, filename, {rev: doc._rev})
+        .then(function(meta) {
+          if (meta.digest === doc._attachments[filename].digest) {
+            return false;
+          }
 
-  return target.get(doc._id).then(function (localDoc) {
-    return Promise.all(filenames.map(function (filename) {
-      if (fileHasChanged(localDoc, doc, filename)) {
-        return src.getAttachment(doc._id, filename);
-      }
+          return src.getAttachment(doc._id, filename, {rev: doc._rev});
+        }).catch(function(error) {
+          if (error.status !== 404) {
+            throw error;
+          }
 
-      return target.getAttachment(localDoc._id, filename);
-    }));
-  }).catch(function (error) {
-    /* istanbul ignore if */
-    if (error.status !== 404) {
-      throw error;
-    }
-
-    return getDocAttachments(src, doc);
-  });
+          return src.getAttachment(doc._id, filename, {rev: doc._rev});
+        });
+  }));
 }
 
 function createBulkGetOpts(diffs) {
@@ -106,10 +94,13 @@ function getDocs(src, target, diffs, state) {
                            var filenames = Object.keys(remoteDoc._attachments);
                            attachments
                              .forEach(function (attachment, i) {
-                                        var att = remoteDoc._attachments[filenames[i]];
-                                        delete att.stub;
-                                        delete att.length;
-                                        att.data = attachment;
+                                        // `attachment` is `false` if target digest equals src digest
+                                        if (attachment) {
+                                          var att = remoteDoc._attachments[filenames[i]];
+                                          delete att.stub;
+                                          delete att.length;
+                                          att.data = attachment;
+                                        }
                                       });
 
                                       return remoteDoc;

--- a/packages/node_modules/pouchdb-replication/src/getDocs.js
+++ b/packages/node_modules/pouchdb-replication/src/getDocs.js
@@ -15,13 +15,14 @@ function getDocAttachmentsFromTargetOrSource(target, src, doc) {
 
   if (target.getAttachmentMetadata) {
     return Promise.all(filenames.map(function(filename) {
-      return target.getAttachmentMetadata(doc._id, filename, {rev: doc._rev})
-          .then(function(meta) {
-            if (meta.digest && meta.digest === doc._attachments[filename].digest) {
+      return target.getAttachmentMetadata(doc._id, filename)
+          .then(function(metadata) {
+            if (metadata.digest === doc._attachments[filename].digest) {
               return false; // returning `false` for `getDocs`
             }
 
             return src.getAttachment(doc._id, filename, {rev: doc._rev});
+
           }).catch(function(error) {
             if (error.status !== 404) {
               throw error;
@@ -41,6 +42,7 @@ function getDocAttachmentsFromTargetOrSource(target, src, doc) {
 
             return false; // returning `false` for `getDocs`
           }));
+
         }).catch(function(error) {
           if (error.status !== 404) {
             throw error;
@@ -123,7 +125,10 @@ function getDocs(src, target, diffs, state) {
                                           delete att.length;
                                           att.data = attachment;
                                         } else {
-                                          remoteDoc._attachments[filenames[i]] = {stub: true};
+                                          remoteDoc._attachments[filenames[i]] = {
+                                            stub: true,
+                                            content_type: remoteDoc._attachments[filenames[i]].content_type
+                                          };
                                         }
                                       });
 

--- a/packages/node_modules/pouchdb-replication/src/getDocs.js
+++ b/packages/node_modules/pouchdb-replication/src/getDocs.js
@@ -100,6 +100,8 @@ function getDocs(src, target, diffs, state) {
                                           delete att.stub;
                                           delete att.length;
                                           att.data = attachment;
+                                        } else {
+                                          remoteDoc._attachments[filenames[i]] = {stub: true};
                                         }
                                       });
 

--- a/packages/node_modules/pouchdb-replication/src/getDocs.js
+++ b/packages/node_modules/pouchdb-replication/src/getDocs.js
@@ -17,7 +17,7 @@ function getDocAttachmentsFromTargetOrSource(target, src, doc) {
     return target.getAttachmentMeta(doc._id, filename, {rev: doc._rev})
         .then(function(meta) {
           if (meta.digest === doc._attachments[filename].digest) {
-            return false;
+            return false; // returning `false` for `getDocs`
           }
 
           return src.getAttachment(doc._id, filename, {rev: doc._rev});

--- a/packages/node_modules/pouchdb-replication/src/getDocs.js
+++ b/packages/node_modules/pouchdb-replication/src/getDocs.js
@@ -13,22 +13,44 @@ function fileHasChanged(localDoc, remoteDoc, filename) {
 function getDocAttachmentsFromTargetOrSource(target, src, doc) {
   var filenames = Object.keys(doc._attachments);
 
-  return Promise.all(filenames.map(function(filename) {
-    return target.getAttachmentMeta(doc._id, filename, {rev: doc._rev})
-        .then(function(meta) {
-          if (meta.digest === doc._attachments[filename].digest) {
-            return false; // returning `false` for `getDocs`
-          }
+  if (target.getAttachmentMetadata) {
+    return Promise.all(filenames.map(function(filename) {
+      return target.getAttachmentMetadata(doc._id, filename, {rev: doc._rev})
+          .then(function(meta) {
+            if (meta.digest && meta.digest === doc._attachments[filename].digest) {
+              return false; // returning `false` for `getDocs`
+            }
 
-          return src.getAttachment(doc._id, filename, {rev: doc._rev});
+            return src.getAttachment(doc._id, filename, {rev: doc._rev});
+          }).catch(function(error) {
+            if (error.status !== 404) {
+              throw error;
+            }
+
+            return src.getAttachment(doc._id, filename, {rev: doc._rev});
+          });
+    }));
+
+  } else {
+    return target.get(doc._id)
+        .then(function(remoteDoc) {
+          return Promise.all(filenames.map(function(filename) {
+            if (fileHasChanged(remoteDoc, doc, filename)) {
+              return src.getAttachment(doc._id, filename, {rev: doc._rev});
+            }
+
+            return false; // returning `false` for `getDocs`
+          }));
         }).catch(function(error) {
           if (error.status !== 404) {
             throw error;
           }
 
-          return src.getAttachment(doc._id, filename, {rev: doc._rev});
+          return Promise.all(filenames.map(function(filename) {
+            return src.getAttachment(doc._id, filename, {rev: doc._rev}));
+          }));
         });
-  }));
+  }
 }
 
 function createBulkGetOpts(diffs) {


### PR DESCRIPTION
Avoid unneeded attachment data in replication requests, even if the target is remote.