### PR TITLE
replication with extra get

### DIFF
--- a/packages/node_modules/pouchdb-replication/src/getDocs.js
+++ b/packages/node_modules/pouchdb-replication/src/getDocs.js
@@ -18,12 +18,7 @@ function getDocAttachments(db, doc) {
 }
 
 function getDocAttachmentsFromTargetOrSource(target, src, doc) {
-  var doCheckForLocalAttachments = isRemote(src) && !isRemote(target);
   var filenames = Object.keys(doc._attachments);
-
-  if (!doCheckForLocalAttachments) {
-    return getDocAttachments(src, doc);
-  }
 
   return target.get(doc._id).then(function (localDoc) {
     return Promise.all(filenames.map(function (filename) {
@@ -31,7 +26,7 @@ function getDocAttachmentsFromTargetOrSource(target, src, doc) {
         return src.getAttachment(doc._id, filename);
       }
 
-      return target.getAttachment(localDoc._id, filename);
+      return false; // returning `false` for `getDocs`
     }));
   }).catch(function (error) {
     /* istanbul ignore if */
@@ -106,10 +101,13 @@ function getDocs(src, target, diffs, state) {
                            var filenames = Object.keys(remoteDoc._attachments);
                            attachments
                              .forEach(function (attachment, i) {
-                                        var att = remoteDoc._attachments[filenames[i]];
-                                        delete att.stub;
-                                        delete att.length;
-                                        att.data = attachment;
+                                        // `attachment` is `false` if target digest equals src digest
+                                        if (attachment) {
+                                          var att = remoteDoc._attachments[filenames[i]];
+                                          delete att.stub;
+                                          delete att.length;
+                                          att.data = attachment;
+                                        }
                                       });
 
                                       return remoteDoc;

--- a/packages/node_modules/pouchdb-replication/src/getDocs.js
+++ b/packages/node_modules/pouchdb-replication/src/getDocs.js
@@ -107,6 +107,8 @@ function getDocs(src, target, diffs, state) {
                                           delete att.stub;
                                           delete att.length;
                                           att.data = attachment;
+                                        } else {
+                                          remoteDoc._attachments[filenames[i]] = {stub: true};
                                         }
                                       });
 


### PR DESCRIPTION
Avoid unneeded attachment data in replication requests, event if the target is remote